### PR TITLE
Add simple combine by key operator

### DIFF
--- a/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionOps.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionOps.scala
@@ -1,7 +1,5 @@
 package com.danielwestheide.kontextfrei
 
-import org.apache.spark.rdd.RDD
-
 import scala.collection.Map
 import scala.collection.immutable.Seq
 import scala.reflect.ClassTag
@@ -159,6 +157,11 @@ object DCollectionOps {
         seqOp: (C, B) => C,
         combOp: (C, C) => C): DCollection[(A, C)] =
       self.aggregateByKey(coll)(zeroValue)(seqOp)(combOp)
+    def combineByKey[C: ClassTag](
+        createCombiner: B => C,
+        mergeValue: (C, B) => C,
+        mergeCombiners: (C, C) => C): DCollection[(A, C)] =
+      self.combineByKey(coll)(createCombiner, mergeValue, mergeCombiners)
     def countByKey(): Map[A, Long] = self.countByKey(coll)
     def collectAsMap(): Map[A, B]  = self.collectAsMap(coll)
   }

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionOps.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionOps.scala
@@ -1,5 +1,7 @@
 package com.danielwestheide.kontextfrei
 
+import org.apache.spark.rdd.RDD
+
 import scala.collection.Map
 import scala.collection.immutable.Seq
 import scala.reflect.ClassTag
@@ -61,6 +63,11 @@ trait DCollectionOps[DCollection[_]] {
   def aggregateByKey[A: ClassTag, B: ClassTag, C: ClassTag](
       xs: DCollection[(A, B)])(zeroValue: C)(seqOp: (C, B) => C)(
       combOp: (C, C) => C): DCollection[(A, C)]
+  def combineByKey[A: ClassTag, B: ClassTag, C: ClassTag](
+      xs: DCollection[(A, B)])(
+      createCombiner: B => C,
+      mergeValue: (C, B) => C,
+      mergeCombiners: (C, C) => C): DCollection[(A, C)]
 
   // actions:
   def collectAsArray[A: ClassTag](as: DCollection[A]): Array[A]

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/RDDCollectionOps.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/RDDCollectionOps.scala
@@ -71,6 +71,11 @@ trait RDDCollectionOps {
           xs: RDD[(A, B)])(zeroValue: C)(seqOp: (C, B) => C)(
           combOp: (C, C) => C): RDD[(A, C)] =
         xs.aggregateByKey(zeroValue)(seqOp, combOp)
+      def combineByKey[A: ClassTag, B: ClassTag, C: ClassTag](xs: RDD[(A, B)])(
+          createCombiner: B => C,
+          mergeValue: (C, B) => C,
+          mergeCombiners: (C, C) => C): RDD[(A, C)] =
+        xs.combineByKey(createCombiner, mergeValue, mergeCombiners)
 
       def collectAsArray[A: ClassTag](as: RDD[A]): Array[A] = as.collect()
       def count[A](as: RDD[A]): Long                        = as.count()

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/StreamCollectionOps.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/StreamCollectionOps.scala
@@ -136,21 +136,7 @@ trait StreamCollectionOps {
       def aggregateByKey[A: ClassTag, B: ClassTag, C: ClassTag](
           xs: Stream[(A, B)])(zeroValue: C)(seqOp: (C, B) => C)(
           combOp: (C, C) => C): Stream[(A, C)] = {
-        val grouped = xs.groupBy(_._1) map {
-          case (a, ys) => a -> ys.map(x => x._2)
-        }
-        grouped.toStream.map {
-          case (a, bs) =>
-            val c = bs
-              .grouped(2)
-              .toStream
-              .par
-              .map { partition =>
-                partition.foldLeft(zeroValue)(seqOp)
-              }
-              .reduce(combOp)
-            (a, c)
-        }
+        combineByKey(xs)(b => seqOp(zeroValue, b), seqOp, combOp)
       }
 
       def combineByKey[A: ClassTag, B: ClassTag, C: ClassTag](

--- a/core/src/test/scala/com/danielwestheide/kontextfrei/DCollectionOpsProperties.scala
+++ b/core/src/test/scala/com/danielwestheide/kontextfrei/DCollectionOpsProperties.scala
@@ -443,7 +443,7 @@ trait DCollectionOpsProperties[DColl[_]] extends BaseSpec[DColl] {
     }
   }
 
-  property("values == map(_._2") {
+  property("values == map(_._2)") {
     forAll { (xs: List[(Int, String)]) =>
       unit(xs).values.collect() mustEqual unit(xs.map(_._2)).collect()
     }
@@ -475,6 +475,18 @@ trait DCollectionOpsProperties[DColl[_]] extends BaseSpec[DColl] {
     "aggregateByKey applies associative functions on all elements with the same key") {
     forAll { (xs: List[(String, String)]) =>
       val result  = unit(xs).aggregateByKey(0)(_ + _.length, _ + _).collect()
+      val xsByKey = xs.groupBy(_._1).mapValues(_.map(_._2))
+      Inspectors.forAll(result) {
+        case (k, v) => v mustEqual xsByKey(k).aggregate(0)(_ + _.length, _ + _)
+      }
+    }
+  }
+
+  property(
+    "combineByKey applies associative functions on all elements with the same key") {
+    forAll { (xs: List[(String, String)]) =>
+      val result =
+        unit(xs).combineByKey[Int](_.length, _ + _.length, _ + _).collect()
       val xsByKey = xs.groupBy(_._1).mapValues(_.map(_._2))
       Inspectors.forAll(result) {
         case (k, v) => v mustEqual xsByKey(k).aggregate(0)(_ + _.length, _ + _)


### PR DESCRIPTION
This adds a simple `combineByKeyOperator`, as defined in Spark's `RDD`. See #6.