### PR TITLE
Ensure function signatures are consistent

### DIFF
--- a/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionBaseFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionBaseFunctions.scala
@@ -34,8 +34,8 @@ private[kontextfrei] trait DCollectionBaseFunctions[DCollection[_]] {
 
   def keyBy[A: ClassTag, B](as: DCollection[A])(f: A => B): DCollection[(B, A)]
 
-  def union[A: ClassTag](xs: DCollection[A],
-                         ys: DCollection[A]): DCollection[A]
+  def union[A: ClassTag](xs: DCollection[A])(
+      ys: DCollection[A]): DCollection[A]
 
   def sortBy[A: ClassTag, B: ClassTag: Ordering](as: DCollection[A])(
       f: A => B)(ascending: Boolean): DCollection[A]

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionPairFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionPairFunctions.scala
@@ -31,18 +31,19 @@ private[kontextfrei] trait DCollectionPairFunctions[DCollection[_]] {
       xs: DCollection[(A, B)])(f: B => TraversableOnce[C]): DCollection[(A, C)]
 
   def foldByKey[A: ClassTag, B: ClassTag](xs: DCollection[(A, B)])(
-      zeroValue: B)(func: (B, B) => B): DCollection[(A, B)]
+      zeroValue: B,
+      func: (B, B) => B): DCollection[(A, B)]
 
   def reduceByKey[A: ClassTag, B: ClassTag](xs: DCollection[(A, B)])(
       f: (B, B) => B): DCollection[(A, B)]
 
   def aggregateByKey[A: ClassTag, B: ClassTag, C: ClassTag](
-      xs: DCollection[(A, B)])(zeroValue: C)(seqOp: (C, B) => C)(
+      xs: DCollection[(A, B)])(zeroValue: C)(
+      seqOp: (C, B) => C,
       combOp: (C, C) => C): DCollection[(A, C)]
 
   def combineByKey[A: ClassTag, B: ClassTag, C: ClassTag](
-      xs: DCollection[(A, B)])(
-      createCombiner: B => C,
+      xs: DCollection[(A, B)])(createCombiner: B => C)(
       mergeValue: (C, B) => C,
       mergeCombiners: (C, C) => C): DCollection[(A, C)]
 

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/rdd/RDDBaseFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/rdd/RDDBaseFunctions.scala
@@ -45,7 +45,7 @@ private[kontextfrei] trait RDDBaseFunctions
       f: A => B): RDD[(B, A)] =
     as.keyBy(f)
 
-  override final def union[A: ClassTag](xs: RDD[A], ys: RDD[A]): RDD[A] =
+  override final def union[A: ClassTag](xs: RDD[A])(ys: RDD[A]): RDD[A] =
     xs.union(ys)
 
   override final def sortBy[A: ClassTag, B: ClassTag: Ordering](as: RDD[A])(

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/rdd/RDDPairFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/rdd/RDDPairFunctions.scala
@@ -42,18 +42,19 @@ private[kontextfrei] trait RDDPairFunctions
       f: (B, B) => B): RDD[(A, B)] =
     xs.reduceByKey(f)
 
-  override final def foldByKey[A: ClassTag, B: ClassTag](xs: RDD[(A, B)])(
-      zeroValue: B)(f: (B, B) => B): RDD[(A, B)] = xs.foldByKey(zeroValue)(f)
+  override final def foldByKey[A: ClassTag, B: ClassTag](
+      xs: RDD[(A, B)])(zeroValue: B, f: (B, B) => B): RDD[(A, B)] =
+    xs.foldByKey(zeroValue)(f)
 
   override final def aggregateByKey[A: ClassTag, B: ClassTag, C: ClassTag](
-      xs: RDD[(A, B)])(zeroValue: C)(seqOp: (C, B) => C)(
-      combOp: (C, C) => C): RDD[(A, C)] =
+      xs: RDD[(A, B)])(zeroValue: C)(seqOp: (C, B) => C,
+                                     combOp: (C, C) => C): RDD[(A, C)] =
     xs.aggregateByKey(zeroValue)(seqOp, combOp)
 
   override final def combineByKey[A: ClassTag, B: ClassTag, C: ClassTag](
-      xs: RDD[(A, B)])(createCombiner: B => C,
-                       mergeValue: (C, B) => C,
-                       mergeCombiners: (C, C) => C): RDD[(A, C)] =
+      xs: RDD[(A, B)])(createCombiner: B => C)(
+      mergeValue: (C, B) => C,
+      mergeCombiners: (C, C) => C): RDD[(A, C)] =
     xs.combineByKey(createCombiner, mergeValue, mergeCombiners)
 
   override final def countByKey[A: ClassTag, B: ClassTag](

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/stream/StreamBaseFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/stream/StreamBaseFunctions.scala
@@ -52,8 +52,8 @@ private[kontextfrei] trait StreamBaseFunctions
       f: A => B): Stream[(B, A)] =
     as.map(a => f(a) -> a)
 
-  override final def union[A: ClassTag](xs: Stream[A],
-                                        ys: Stream[A]): Stream[A] =
+  override final def union[A: ClassTag](xs: Stream[A])(
+      ys: Stream[A]): Stream[A] =
     xs.union(ys)
 
   override final def sortBy[A: ClassTag, B: ClassTag: Ordering](as: Stream[A])(

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/stream/StreamPairFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/stream/StreamPairFunctions.scala
@@ -88,8 +88,8 @@ private[kontextfrei] trait StreamPairFunctions
     grouped.toStream.map { case (a, bs) => (a, bs reduce f) }
   }
 
-  override final def foldByKey[A: ClassTag, B: ClassTag](xs: Stream[(A, B)])(
-      zeroValue: B)(f: (B, B) => B): Stream[(A, B)] = {
+  override final def foldByKey[A: ClassTag, B: ClassTag](
+      xs: Stream[(A, B)])(zeroValue: B, f: (B, B) => B): Stream[(A, B)] = {
     val grouped = xs.groupBy(_._1) map {
       case (a, ys) => a -> ys.map(x => x._2)
     }
@@ -97,15 +97,16 @@ private[kontextfrei] trait StreamPairFunctions
   }
 
   override final def aggregateByKey[A: ClassTag, B: ClassTag, C: ClassTag](
-      xs: Stream[(A, B)])(zeroValue: C)(seqOp: (C, B) => C)(
+      xs: Stream[(A, B)])(zeroValue: C)(
+      seqOp: (C, B) => C,
       combOp: (C, C) => C): Stream[(A, C)] = {
-    combineByKey(xs)(b => seqOp(zeroValue, b), seqOp, combOp)
+    combineByKey(xs)(b => seqOp(zeroValue, b))(seqOp, combOp)
   }
 
   override final def combineByKey[A: ClassTag, B: ClassTag, C: ClassTag](
-      xs: Stream[(A, B)])(createCombiner: B => C,
-                          mergeValue: (C, B) => C,
-                          mergeCombiners: (C, C) => C): Stream[(A, C)] = {
+      xs: Stream[(A, B)])(createCombiner: B => C)(
+      mergeValue: (C, B) => C,
+      mergeCombiners: (C, C) => C): Stream[(A, C)] = {
     val grouped = xs.groupBy(_._1) map {
       case (a, ys) => a -> ys.map(x => x._2)
     }

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/syntax/BaseSyntax.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/syntax/BaseSyntax.scala
@@ -39,9 +39,9 @@ class BaseSyntax[DCollection[_], A: ClassTag](
   final def keyBy[B](f: A => B): DCollection[(B, A)] = self.keyBy(coll)(f)
 
   final def union(other: DCollection[A]): DCollection[A] =
-    self.union(coll, other)
+    self.union(coll)(other)
 
-  final def ++(other: DCollection[A]): DCollection[A] = self.union(coll, other)
+  final def ++(other: DCollection[A]): DCollection[A] = self.union(coll)(other)
 
   final def sortBy[B: ClassTag: Ordering](
       f: A => B,

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/syntax/PairSyntax.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/syntax/PairSyntax.scala
@@ -40,18 +40,18 @@ class PairSyntax[DCollection[_], A: ClassTag, B: ClassTag](
     self.reduceByKey(coll)(f)
 
   final def foldByKey(zeroValue: B)(f: (B, B) => B): DCollection[(A, B)] =
-    self.foldByKey(coll)(zeroValue)(f)
+    self.foldByKey(coll)(zeroValue, f)
 
   final def aggregateByKey[C: ClassTag](zeroValue: C)(
       seqOp: (C, B) => C,
       combOp: (C, C) => C): DCollection[(A, C)] =
-    self.aggregateByKey(coll)(zeroValue)(seqOp)(combOp)
+    self.aggregateByKey(coll)(zeroValue)(seqOp, combOp)
 
   final def combineByKey[C: ClassTag](
       createCombiner: B => C,
       mergeValue: (C, B) => C,
       mergeCombiners: (C, C) => C): DCollection[(A, C)] =
-    self.combineByKey(coll)(createCombiner, mergeValue, mergeCombiners)
+    self.combineByKey(coll)(createCombiner)(mergeValue, mergeCombiners)
 
   final def countByKey(): Map[A, Long] = self.countByKey(coll)
 

--- a/core/src/test/scala/com/danielwestheide/kontextfrei/DCollectionOpsProperties.scala
+++ b/core/src/test/scala/com/danielwestheide/kontextfrei/DCollectionOpsProperties.scala
@@ -436,7 +436,7 @@ trait DCollectionOpsProperties[DColl[_]] extends BaseSpec[DColl] {
     }
   }
 
-  property("keys == map(_._1") {
+  property("keys == map(_._1)") {
     forAll { (xs: List[(Int, String)]) =>
       unit(xs).keys.collect() mustEqual unit(xs.map(_._1)).collect()
     }


### PR DESCRIPTION
This means that syntax is consistent with RDD, and that our ops use currying in a consistent manner, only where it benefits type inference.

This closes #24.