### PR TITLE
Provide ScalaTest Collecting instances for DCollections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,9 @@ lazy val scalaTest =
   Project(id = "kontextfrei-scalatest", base = file("scalatest"))
     .settings(common)
     .settings(
-      libraryDependencies ++= Seq(spark(sparkVersion.value), scalatest))
+      libraryDependencies ++= Seq(spark(sparkVersion.value),
+                                  scalatest,
+                                  scalacheck % "test"))
     .dependsOn(core)
 
 lazy val root = Project(id = "kontextfrei", base = file("."))

--- a/scalatest/src/main/scala/com/danielwestheide/kontextfrei/scalatest/CollectingInstances.scala
+++ b/scalatest/src/main/scala/com/danielwestheide/kontextfrei/scalatest/CollectingInstances.scala
@@ -1,0 +1,27 @@
+package com.danielwestheide.kontextfrei.scalatest
+
+import com.danielwestheide.kontextfrei.DCollectionOps
+import org.scalatest.enablers.Collecting
+
+import scala.collection.GenTraversable
+import scala.reflect.ClassTag
+
+trait CollectingInstances {
+  implicit def collectingDCollection[A: ClassTag, DCollection[_]](
+      implicit ops: DCollectionOps[DCollection])
+    : Collecting[A, DCollection[A]] = new Collecting[A, DCollection[A]] {
+    override def loneElementOf(collection: DCollection[A]): Option[A] = {
+      val as = ops.collectAsArray(collection)
+      if (as.length == 1) Some(as(0)) else None
+    }
+
+    override def sizeOf(collection: DCollection[A]): Int =
+      ops.count(collection).toInt
+
+    override def genTraversableFrom(
+        collection: DCollection[A]): GenTraversable[A] =
+      ops.collectAsArray(collection)
+  }
+}
+
+object CollectingInstances extends CollectingInstances

--- a/scalatest/src/test/scala/com/danielwestheide/kontextfrei/scalatest/CollectingInstancesProperties.scala
+++ b/scalatest/src/test/scala/com/danielwestheide/kontextfrei/scalatest/CollectingInstancesProperties.scala
@@ -1,0 +1,73 @@
+package com.danielwestheide.kontextfrei.scalatest
+
+import org.apache.spark.rdd.RDD
+import org.scalatest.enablers.Collecting
+import org.scalatest.{Inspectors, PropSpec}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+trait CollectingInstancesProperties[DColl[_]]
+    extends PropSpec
+    with GeneratorDrivenPropertyChecks
+    with KontextfreiSpec[DColl]
+    with CollectingInstances {
+
+  property("There is a Collecting instance for DCollection") {
+    forAll { (xs: List[String]) =>
+      val dcoll = ops.unit(xs)
+      Inspectors.forAll(dcoll) { x =>
+        assert(xs.contains(x))
+      }
+    }
+  }
+
+  property(
+    "Collecting nature of DCollection returns the original size of the input sequence") {
+    forAll { (xs: List[String]) =>
+      val dcoll = ops.unit(xs)
+      assert(
+        implicitly[Collecting[String, DColl[String]]]
+          .sizeOf(dcoll) === xs.size)
+    }
+  }
+
+  property(
+    "Collecting nature of DCollection returns the Some loneElement if input sequence has exactly one element") {
+    forAll { (x: String) =>
+      val dcoll = ops.unit(List(x))
+      assert(
+        implicitly[Collecting[String, DColl[String]]]
+          .loneElementOf(dcoll) === Some(x))
+    }
+  }
+
+  property(
+    "Collecting nature of DCollection returns the None as loneElement if input sequence as more than one element") {
+    forAll { (xs: List[String]) =>
+      whenever(xs.size > 1) {
+        val dcoll = ops.unit(xs)
+        assert(
+          implicitly[Collecting[String, DColl[String]]]
+            .loneElementOf(dcoll)
+            .isEmpty)
+      }
+    }
+  }
+
+  property(
+    "Collecting nature of DCollection returns the None as loneElement if input sequence is empty") {
+    val dcoll = ops.unit(List.empty[String])
+    assert(
+      implicitly[Collecting[String, DColl[String]]]
+        .loneElementOf(dcoll)
+        .isEmpty)
+  }
+
+}
+
+class CollectionInstancesStreamSpec
+    extends CollectingInstancesProperties[Stream]
+    with StreamSpec
+
+class CollectionInstancesRDDSpec
+    extends CollectingInstancesProperties[RDD]
+    with RDDSpec


### PR DESCRIPTION
This provides ScalaTest `Collecting` instances for any `DCollection[_]` for which there are `DCollectionOps`, making it easier to use ScalaTest features like Inspectors etc. with them. See #11.