### PR TITLE
Add repartition operator

### DIFF
--- a/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionBaseFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/DCollectionBaseFunctions.scala
@@ -49,4 +49,7 @@ private[kontextfrei] trait DCollectionBaseFunctions[DCollection[_]] {
 
   def first[A: ClassTag](as: DCollection[A]): A
 
+  def repartition[A: ClassTag](as: DCollection[A])(
+      numPartitions: Int): DCollection[A]
+
 }

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/rdd/RDDBaseFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/rdd/RDDBaseFunctions.scala
@@ -63,4 +63,7 @@ private[kontextfrei] trait RDDBaseFunctions
 
   override final def first[A: ClassTag](as: RDD[A]): A = as.first()
 
+  override def repartition[A: ClassTag](as: RDD[A])(
+      numPartitions: Int): RDD[A] = as.repartition(numPartitions)
+
 }

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/stream/StreamBaseFunctions.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/stream/StreamBaseFunctions.scala
@@ -75,4 +75,7 @@ private[kontextfrei] trait StreamBaseFunctions
       throw new UnsupportedOperationException("empty collection")
     }
 
+  override def repartition[A: ClassTag](as: Stream[A])(
+      numPartitions: Int): Stream[A] = as
+
 }

--- a/core/src/main/scala/com/danielwestheide/kontextfrei/syntax/BaseSyntax.scala
+++ b/core/src/main/scala/com/danielwestheide/kontextfrei/syntax/BaseSyntax.scala
@@ -57,4 +57,7 @@ class BaseSyntax[DCollection[_], A: ClassTag](
 
   final def first(): A = self.first(coll)
 
+  final def repartition(numPartitions: Int): DCollection[A] =
+    self.repartition(coll)(numPartitions)
+
 }

--- a/core/src/test/scala/com/danielwestheide/kontextfrei/DCollectionOpsProperties.scala
+++ b/core/src/test/scala/com/danielwestheide/kontextfrei/DCollectionOpsProperties.scala
@@ -1,8 +1,11 @@
 package com.danielwestheide.kontextfrei
 
-import org.scalatest.Inspectors
+import org.scalacheck.Gen
+import org.scalatest.{DiagrammedAssertions, Inspectors}
 
-trait DCollectionOpsProperties[DColl[_]] extends BaseSpec[DColl] {
+trait DCollectionOpsProperties[DColl[_]]
+    extends BaseSpec[DColl]
+    with DiagrammedAssertions {
 
   import syntax.Imports._
   import org.scalatest.OptionValues._
@@ -537,6 +540,13 @@ trait DCollectionOpsProperties[DColl[_]] extends BaseSpec[DColl] {
           .first() mustEqual xs.toList.sorted.head
         unit(xs.toList).first() mustEqual xs.head
       }
+    }
+  }
+
+  property("repartition doesn't have any visible effect on a DCollection") {
+    forAll(Gen.listOfN(4, Gen.alphaStr)) { xs =>
+      val result = unit(xs).repartition(2).collect().toList
+      assert(result.sorted === xs.sorted)
     }
   }
 


### PR DESCRIPTION
For Stream, this is implemented as a noop, because there isn't any partitioning at all on a Stream.

This closes #2.